### PR TITLE
Add dat.GUI cube controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
 <head>
 	<title>3d example using three.js and multiple windows</title>
-	<script type="text/javascript" src="three.r124.min.js"></script>
+        <script type="text/javascript" src="three.r124.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/dat.gui@0.7.9/build/dat.gui.min.js"></script>
 	<style type="text/css">
 		
 		*

--- a/main.js
+++ b/main.js
@@ -2,11 +2,29 @@ import WindowManager from './WindowManager.js'
 
 
 
-const t = THREE;
+let t = THREE;
 let camera, scene, renderer, world;
 let near, far;
 let pixR = window.devicePixelRatio ? window.devicePixelRatio : 1;
 let cubes = [];
+let gui;
+let cubeControls = {
+    width: 150,
+    height: 150,
+    subDepth: 150,
+    rows: 1,
+    columns: 1,
+    posX: 0,
+    posY: 0,
+    velocityX: 0,
+    velocityY: 0,
+    color: '#ff0000',
+    subColor: '#ff0000',
+    matchDepth: false,
+    rotX: 0,
+    rotY: 0,
+    rotZ: 0
+};
 let sceneOffsetTarget = {x: 0, y: 0};
 let sceneOffset = {x: 0, y: 0};
 
@@ -56,8 +74,9 @@ else
 
 		// add a short timeout because window.offsetX reports wrong values before a short period 
 		setTimeout(() => {
-			setupScene();
-			setupWindowManager();
+                        setupScene();
+                        setupGUI();
+                        setupWindowManager();
 			resize();
 			updateWindowShape(false);
 			render();
@@ -65,9 +84,9 @@ else
 		}, 500)	
 	}
 
-	function setupScene ()
-	{
-		camera = new t.OrthographicCamera(0, 0, window.innerWidth, window.innerHeight, -10000, 10000);
+        function setupScene ()
+        {
+                camera = new t.OrthographicCamera(0, 0, window.innerWidth, window.innerHeight, -10000, 10000);
 		
 		camera.position.z = 2.5;
 		near = camera.position.z - .5;
@@ -83,9 +102,29 @@ else
 	  	world = new t.Object3D();
 		scene.add(world);
 
-		renderer.domElement.setAttribute("id", "scene");
-		document.body.appendChild( renderer.domElement );
-	}
+                renderer.domElement.setAttribute("id", "scene");
+                document.body.appendChild( renderer.domElement );
+        }
+
+        function setupGUI ()
+        {
+                gui = new dat.GUI();
+                gui.add(cubeControls, 'width', 50, 300, 10).onChange(updateCubeSize);
+                gui.add(cubeControls, 'height', 50, 300, 10).onChange(updateCubeSize);
+                gui.add(cubeControls, 'rows', 1, 10, 1).onChange(updateSubCubeLayout);
+                gui.add(cubeControls, 'columns', 1, 10, 1).onChange(updateSubCubeLayout);
+                gui.add(cubeControls, 'subDepth', 10, 300, 10).onChange(() => { updateCubeSize(); updateSubCubeLayout(); });
+                gui.add(cubeControls, 'posX', -300, 300, 1);
+                gui.add(cubeControls, 'posY', -300, 300, 1);
+                gui.add(cubeControls, 'velocityX', -10, 10, 0.1);
+                gui.add(cubeControls, 'velocityY', -10, 10, 0.1);
+                gui.addColor(cubeControls, 'color').onChange(updateCubeColor);
+                gui.addColor(cubeControls, 'subColor').onChange(updateSubCubeColor);
+                gui.add(cubeControls, 'matchDepth').onChange(updateCubeSize);
+                gui.add(cubeControls, 'rotX', 0, Math.PI * 2, 0.1);
+                gui.add(cubeControls, 'rotY', 0, Math.PI * 2, 0.1);
+                gui.add(cubeControls, 'rotZ', 0, Math.PI * 2, 0.1);
+        }
 
 	function setupWindowManager ()
 	{
@@ -119,23 +158,95 @@ else
 
 		cubes = [];
 
-		// add new cubes based on the current window setup
-		for (let i = 0; i < wins.length; i++)
-		{
-			let win = wins[i];
+                // add new cubes based on the current window setup
+                for (let i = 0; i < wins.length; i++)
+                {
+                        let win = wins[i];
 
-			let c = new t.Color();
-			c.setHSL(i * .1, 1.0, .5);
+                        let depth = cubeControls.matchDepth ? cubeControls.subDepth : cubeControls.width;
+                        let cube = new t.Mesh(
+                                new t.BoxGeometry(cubeControls.width, cubeControls.height, depth),
+                                new t.MeshBasicMaterial({color: cubeControls.color, wireframe: true})
+                        );
+                        cube.position.x = win.shape.x + (win.shape.w * .5);
+                        cube.position.y = win.shape.y + (win.shape.h * .5);
 
-			let s = 100 + i * 50;
-			let cube = new t.Mesh(new t.BoxGeometry(s, s, s), new t.MeshBasicMaterial({color: c , wireframe: true}));
-			cube.position.x = win.shape.x + (win.shape.w * .5);
-			cube.position.y = win.shape.y + (win.shape.h * .5);
+                        createSubCubeGrid(cube);
 
-			world.add(cube);
-			cubes.push(cube);
-		}
-	}
+                        world.add(cube);
+                        cubes.push(cube);
+                }
+        }
+
+       function updateCubeSize ()
+       {
+               cubes.forEach((cube) => {
+                       cube.geometry.dispose();
+                        let depth = cubeControls.matchDepth ? cubeControls.subDepth : cubeControls.width;
+                        cube.geometry = new t.BoxGeometry(cubeControls.width, cubeControls.height, depth);
+                        createSubCubeGrid(cube);
+               });
+       }
+
+        function updateCubeColor ()
+        {
+                cubes.forEach((cube) => {
+                        cube.material.color.set(cubeControls.color);
+                });
+        }
+
+        function updateSubCubeColor ()
+        {
+                cubes.forEach((cube) => {
+                        if (cube.userData.subCubes) {
+                                cube.userData.subCubes.forEach((sc) => {
+                                        sc.material.color.set(cubeControls.subColor);
+                                });
+                        }
+                });
+        }
+
+        function createSubCubeGrid (cube)
+        {
+                if (!cube.userData.subCubes) cube.userData.subCubes = [];
+
+                cube.userData.subCubes.forEach((sc) => {
+                        cube.remove(sc);
+                        sc.geometry.dispose();
+                        sc.material.dispose();
+                });
+                cube.userData.subCubes = [];
+
+                let rows = Math.max(1, cubeControls.rows | 0);
+                let cols = Math.max(1, cubeControls.columns | 0);
+
+                let subW = cubeControls.width / cols;
+                let subH = cubeControls.height / rows;
+                let subD = cubeControls.subDepth;
+
+                for (let r = 0; r < rows; r++)
+                {
+                        for (let c = 0; c < cols; c++)
+                        {
+                                let sc = new t.Mesh(
+                                        new t.BoxGeometry(subW, subH, subD),
+                                        new t.MeshBasicMaterial({color: cubeControls.subColor, wireframe: true})
+                                );
+                                sc.position.x = -cubeControls.width / 2 + subW * (c + 0.5);
+                                sc.position.y = -cubeControls.height / 2 + subH * (r + 0.5);
+                                cube.add(sc);
+                                cube.userData.subCubes.push(sc);
+                        }
+                }
+        }
+
+        function updateSubCubeLayout ()
+        {
+                cubes.forEach((cube) => {
+                        createSubCubeGrid(cube);
+                });
+                updateSubCubeColor();
+        }
 
 	function updateWindowShape (easing = true)
 	{
@@ -145,9 +256,11 @@ else
 	}
 
 
-	function render ()
-	{
-		let t = getTime();
+        function render ()
+        {
+                let time = getTime();
+                let dt = time - internalTime;
+                internalTime = time;
 
 		windowManager.update();
 
@@ -169,15 +282,21 @@ else
 		{
 			let cube = cubes[i];
 			let win = wins[i];
-			let _t = t;// + i * .2;
+			let _t = time;// + i * .2;
 
-			let posTarget = {x: win.shape.x + (win.shape.w * .5), y: win.shape.y + (win.shape.h * .5)}
+                        let posTarget = {
+                                x: win.shape.x + (win.shape.w * .5) + cubeControls.posX,
+                                y: win.shape.y + (win.shape.h * .5) + cubeControls.posY
+                        };
 
-			cube.position.x = cube.position.x + (posTarget.x - cube.position.x) * falloff;
-			cube.position.y = cube.position.y + (posTarget.y - cube.position.y) * falloff;
-			cube.rotation.x = _t * .5;
-			cube.rotation.y = _t * .3;
-		};
+                        cube.position.x = cube.position.x + (posTarget.x - cube.position.x) * falloff;
+                        cube.position.y = cube.position.y + (posTarget.y - cube.position.y) * falloff;
+                        cube.position.x += cubeControls.velocityX * dt;
+                        cube.position.y += cubeControls.velocityY * dt;
+                        cube.rotation.x = cubeControls.rotX + _t * .5;
+                        cube.rotation.y = cubeControls.rotY + _t * .3;
+                        cube.rotation.z = cubeControls.rotZ;
+                };
 
 		renderer.render(scene, camera);
 		requestAnimationFrame(render);


### PR DESCRIPTION
## Summary
- include dat.GUI to control cube parameters
- allow changing cube size and orientation via GUI
- use `let t` as the THREE alias

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68412e47101c832dadae48ba4b99062c