### PR TITLE
Organize loaded subcube data by cube order

### DIFF
--- a/main.js
+++ b/main.js
@@ -425,6 +425,11 @@ else
                         });
                         for (let cube of cubes) {
                                 let subs = await loadSubCubes(db, thisWindowId, cube.userData.winId);
+                                subs.sort((a, b) => {
+                                        let aIdx = getSubCubeOrderIndex(cube, a.row, a.col, a.layer);
+                                        let bIdx = getSubCubeOrderIndex(cube, b.row, b.col, b.layer);
+                                        return aIdx - bIdx;
+                                });
                                 subs.forEach(s => {
                                         if (s.color) applyColorToSubCube(cube, s.row, s.col, s.layer, s.color);
                                         if (s.weight !== undefined) applyWeightToSubCube(cube, s.row, s.col, s.layer, s.weight);


### PR DESCRIPTION
## Summary
- sort subcube entries returned by `loadSubCubes()` using each cube's order

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_68450accf628832db3cfce58cf5554ad